### PR TITLE
Add case insensitivity to absolute IRI detection

### DIFF
--- a/lib/sparql.jison
+++ b/lib/sparql.jison
@@ -57,7 +57,7 @@
     if (iri[0] === '<')
       iri = iri.substring(1, iri.length - 1);
     // Return absolute IRIs unmodified
-    if (/^[a-z]+:/.test(iri))
+    if (/^[a-z]+:/i.test(iri))
       return iri;
     if (!Parser.base)
       throw new Error('Cannot resolve relative IRI ' + iri + ' because no base IRI was set.');


### PR DESCRIPTION
Part of resolving https://github.com/LDflex/LDflex-Comunica/issues/22 as blank nodes of the form `nodeID://1234` from Virtuoso need to be treated as absolute IRI's when going through this parser.